### PR TITLE
refactor: extract DictationEditorController for testability

### DIFF
--- a/src/components/popup/DictationEditor.svelte
+++ b/src/components/popup/DictationEditor.svelte
@@ -1,17 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { EditorState, Compartment, type Extension } from "@codemirror/state";
-  import { EditorView, keymap } from "@codemirror/view";
-  import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-  import {
-    interimField,
-    interimExtensions,
-    insertInterim as doInsertInterim,
-    commitInterim as doCommitInterim,
-    finalizeInterim as doFinalizeInterim,
-    getCommittedText as doGetCommittedText,
-    isInsertingAtCursor as doIsInsertingAtCursor,
-  } from "../../lib/dictationEditorState";
+  import { DictationEditorController } from "../../lib/DictationEditorController";
 
   // --- Props ---
   interface Props {
@@ -26,294 +15,122 @@
 
   let { text = $bindable(), fontFamily, disabled, recording, oninput, oncommit }: Props = $props();
 
-  // --- CM6 setup ---
+  // --- Controller setup ---
 
   let containerEl: HTMLDivElement | undefined = $state();
-  let view: EditorView | undefined = $state();
-
-  /** Compartments for dynamically reconfigurable extensions. */
-  const themeCompartment = new Compartment();
-  const editableCompartment = new Compartment();
-
-  /** Track whether we're dispatching a programmatic change (to avoid feedback loops). */
-  let updatingFromProp = false;
-  let updatingFromCM = false;
-
-  /** Dictation anchor: position where speech text is inserted. Reactive so Popup's $derived can track it. */
-  let dictationAnchor = $state(0);
-
-  function buildTheme(font: string): Extension {
-    return EditorView.theme({
-      "&": {
-        fontSize: "14px",
-        height: "100%",
-        flex: "1",
-      },
-      "&.cm-focused": {
-        outline: "none",
-      },
-      ".cm-content": {
-        fontFamily: font,
-        lineHeight: "1.5",
-        padding: "10px",
-        caretColor: "var(--text-primary)",
-        minHeight: "100%",
-      },
-      ".cm-scroller": {
-        overflow: "auto",
-        height: "100%",
-      },
-      ".cm-line": {
-        padding: "0",
-      },
-      "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
-        backgroundColor: "color-mix(in srgb, var(--accent) 20%, transparent) !important",
-      },
-      ".cm-cursor, .cm-dropCursor": {
-        borderLeftColor: "var(--text-primary)",
-      },
-      ".interim-text": {
-        color: "var(--accent)",
-        opacity: "0.75",
-        fontStyle: "italic",
-        borderBottom: "1px dotted var(--accent)",
-      },
-    });
-  }
-
-  function buildExtensions(font: string): Extension[] {
-    return [
-      themeCompartment.of(buildTheme(font)),
-      ...interimExtensions(),
-      history(),
-      keymap.of([...defaultKeymap, ...historyKeymap]),
-      EditorView.lineWrapping,
-      editableCompartment.of(EditorView.editable.of(!disabled)),
-      // Sync CM6 → parent text on every doc change
-      EditorView.updateListener.of((update) => {
-        if (updatingFromProp) return;
-        if (update.docChanged) {
-          updatingFromCM = true;
-          text = update.state.doc.toString();
-          updatingFromCM = false;
-          oninput?.();
-        }
-        // Track cursor moves: auto-commit interim if cursor leaves the range,
-        // and always update dictationAnchor so new speech inserts at the cursor.
-        if (update.selectionSet && !update.docChanged) {
-          const st = update.state;
-          const range = st.field(interimField);
-          if (range) {
-            autoCommitOnCursorMove(st);
-          } else {
-            // No interim — update anchor to follow cursor clicks
-            dictationAnchor = st.selection.main.head;
-          }
-        }
-      }),
-    ];
-  }
+  let ctrl: DictationEditorController | undefined = $state();
 
   onMount(() => {
     if (!containerEl) return;
-    const state = EditorState.create({
-      doc: text,
-      extensions: buildExtensions(fontFamily),
+    ctrl = new DictationEditorController({
+      initialDoc: text,
+      fontFamily,
+      disabled,
+      callbacks: {
+        onDocChange(newText) {
+          text = newText;
+          oninput?.();
+        },
+        onInterimCommit() {
+          oncommit?.();
+        },
+      },
     });
-    view = new EditorView({
-      state,
-      parent: containerEl,
-    });
-    dictationAnchor = text.length;
+    ctrl.attach(containerEl);
     return () => {
-      view?.destroy();
-      view = undefined;
+      ctrl?.destroy();
+      ctrl = undefined;
     };
   });
 
-  // Sync parent text → CM6 (when parent changes text externally)
+  // Sync parent text → controller (when parent changes text externally)
   $effect(() => {
     const _text = text;
-    if (!view || updatingFromCM) return;
-    const currentDoc = view.state.doc.toString();
-    if (_text !== currentDoc) {
-      updatingFromProp = true;
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: _text },
-      });
-      updatingFromProp = false;
-    }
+    if (!ctrl) return;
+    ctrl.setText(_text);
   });
 
-  // Toggle editable when disabled changes, update theme when font changes
+  // Toggle editable when disabled changes
   $effect(() => {
-    if (!view) return;
-    view.dispatch({
-      effects: [
-        editableCompartment.reconfigure(EditorView.editable.of(!disabled)),
-        themeCompartment.reconfigure(buildTheme(fontFamily)),
-      ],
+    ctrl?.setDisabled(disabled);
+  });
+
+  // Update theme when font changes
+  $effect(() => {
+    ctrl?.setFontFamily(fontFamily);
+  });
+
+  // Keep callbacks in sync when oninput/oncommit change
+  $effect(() => {
+    ctrl?.setCallbacks({
+      onDocChange(newText) {
+        text = newText;
+        oninput?.();
+      },
+      onInterimCommit() {
+        oncommit?.();
+      },
     });
   });
 
-  // --- Auto-commit on cursor move ---
+  // --- Public API (delegates to controller, called from Popup.svelte) ---
 
-  function autoCommitOnCursorMove(state: EditorState) {
-    const range = state.field(interimField);
-    if (!range) return;
-    const cursor = state.selection.main.head;
-    // If cursor is within the interim range, don't commit
-    if (cursor >= range.from && cursor <= range.to) return;
-    // Commit: clear the decoration, anchor moves to cursor
-    commitInterim();
-    oncommit?.();
-    dictationAnchor = cursor;
-  }
-
-  // --- Public API (called from Popup.svelte) ---
-
-  /**
-   * Insert or replace interim text at the dictation anchor.
-   * The text gets the .interim-text decoration.
-   */
   export function insertInterim(newInterim: string) {
-    if (!view) return;
-    updatingFromProp = true;
-    dictationAnchor = doInsertInterim({ view, anchor: dictationAnchor }, newInterim);
-    text = view.state.doc.toString();
-    updatingFromProp = false;
+    ctrl?.insertInterim(newInterim);
+    if (ctrl) text = ctrl.getText();
   }
 
-  /**
-   * Commit interim text: remove decoration, text stays in the document.
-   * Returns the committed text range for logging purposes.
-   */
   export function commitInterim(): { text: string; from: number; to: number } | null {
-    if (!view) return null;
-    updatingFromProp = true;
-    const result = doCommitInterim(view);
-    updatingFromProp = false;
-    if (result) {
-      dictationAnchor = result.newAnchor;
-      return { text: result.text, from: result.from, to: result.to };
-    }
-    return null;
+    return ctrl?.commitInterim() ?? null;
   }
 
-  /**
-   * Finalize interim text in-place: replace the interim range content with
-   * the provider's final text (may differ from interim, e.g. punctuation
-   * corrections), clear the decoration, and advance the anchor.
-   * If no interim range exists, falls back to inserting at the dictation anchor.
-   */
   export function finalizeInterim(finalText: string) {
-    if (!view) return;
-    updatingFromProp = true;
-    dictationAnchor = doFinalizeInterim({ view, anchor: dictationAnchor }, finalText);
-    text = view.state.doc.toString();
-    updatingFromProp = false;
+    ctrl?.finalizeInterim(finalText);
+    if (ctrl) text = ctrl.getText();
   }
 
-  /**
-   * Get text with interim stripped (for copy/submit).
-   */
   export function getCommittedText(): string {
-    if (!view) return text;
-    return doGetCommittedText(view);
+    return ctrl?.getCommittedText() ?? text;
   }
 
-  /**
-   * Get the current dictation anchor position.
-   */
   export function getAnchor(): number {
-    return dictationAnchor;
+    return ctrl?.getAnchor() ?? 0;
   }
 
-  /**
-   * Check if dictation anchor is before doc end (inserting mid-text).
-   * Excludes interim text — if the only content after the anchor is the
-   * decorated interim range, we're appending (not inserting mid-text).
-   */
   export function isInsertingAtCursor(): boolean {
-    if (!view) return dictationAnchor < text.length;
-    return doIsInsertingAtCursor(view, dictationAnchor);
+    return ctrl?.isInsertingAtCursor() ?? false;
   }
 
-  /**
-   * Set cursor and anchor to end of document.
-   */
   export function setCursorEnd() {
-    if (!view) return;
-    const len = view.state.doc.length;
-    view.dispatch({
-      selection: { anchor: len },
-      scrollIntoView: true,
-    });
-    dictationAnchor = len;
+    ctrl?.setCursorEnd();
   }
 
-  /**
-   * Focus the editor.
-   */
   export function focus() {
-    view?.focus();
+    ctrl?.focus();
   }
 
-  /**
-   * Focus the editor and place cursor at end.
-   */
   export function focusAtEnd() {
-    if (!view) return;
-    const len = view.state.doc.length;
-    view.dispatch({
-      selection: { anchor: len },
-      scrollIntoView: true,
-    });
-    dictationAnchor = len;
-    view.focus();
+    ctrl?.focusAtEnd();
   }
 
-  /**
-   * Scroll to the bottom of the editor.
-   */
   export function scrollToBottom() {
-    if (!view) return;
-    view.dispatch({ scrollIntoView: true });
+    ctrl?.scrollToBottom();
   }
 
-  /**
-   * Reset dictation anchor to end of document (e.g. before new recording session).
-   */
   export function resetAnchorToEnd() {
-    if (!view) return;
-    dictationAnchor = view.state.doc.length;
+    ctrl?.resetAnchorToEnd();
   }
 
-  /**
-   * Snap anchor to end + move cursor there (for "resume appending" action).
-   */
   export function snapAnchorToEnd() {
-    if (!view) return;
-    const len = view.state.doc.length;
-    dictationAnchor = len;
-    view.dispatch({
-      selection: { anchor: len },
-    });
+    ctrl?.snapAnchorToEnd();
   }
 
-  /**
-   * Get the document length.
-   */
   export function getDocLength(): number {
-    return view?.state.doc.length ?? text.length;
+    return ctrl?.getDocLength() ?? text.length;
   }
 
-  /**
-   * Check if there's a pending interim range.
-   */
   export function hasInterim(): boolean {
-    if (!view) return false;
-    return view.state.field(interimField) !== null;
+    return ctrl?.hasInterim() ?? false;
   }
 </script>
 

--- a/src/lib/DictationEditorController.ts
+++ b/src/lib/DictationEditorController.ts
@@ -1,0 +1,323 @@
+// ---------------------------------------------------------------------------
+// Headless controller for the CM6 dictation editor.
+//
+// Owns the EditorView, compartments, dictation anchor, and all public methods
+// that were previously trapped inside DictationEditor.svelte.  The Svelte
+// component becomes a thin shell that creates this controller and forwards
+// prop changes.  The controller can be instantiated in unit tests without
+// Svelte or a real DOM (CM6 works fine in jsdom).
+//
+// Pure CM6 state operations are delegated to dictationEditorState.ts —
+// this class adds the orchestration layer (feedback-loop guards, anchor
+// tracking on cursor moves, compartment toggling, auto-commit).
+// ---------------------------------------------------------------------------
+
+import { EditorState, Compartment, type Extension } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  interimField,
+  interimExtensions,
+  insertInterim as doInsertInterim,
+  commitInterim as doCommitInterim,
+  finalizeInterim as doFinalizeInterim,
+  getCommittedText as doGetCommittedText,
+  isInsertingAtCursor as doIsInsertingAtCursor,
+} from "./dictationEditorState";
+
+// --- Public types ---
+
+export interface DictationEditorCallbacks {
+  /** Fires when the user changes the document (typing, paste, delete). */
+  onDocChange?: (newText: string) => void;
+  /** Fires when interim text is auto-committed because the cursor moved. */
+  onInterimCommit?: () => void;
+}
+
+export interface DictationEditorOptions {
+  initialDoc?: string;
+  fontFamily?: string;
+  disabled?: boolean;
+  callbacks?: DictationEditorCallbacks;
+}
+
+// --- Controller ---
+
+export class DictationEditorController {
+  private view: EditorView | undefined;
+  private themeCompartment = new Compartment();
+  private editableCompartment = new Compartment();
+
+  /** Guards to prevent feedback loops between external setText and CM6 updates. */
+  private updatingFromExternal = false;
+  private updatingFromCM = false;
+
+  private _dictationAnchor = 0;
+  private callbacks: DictationEditorCallbacks;
+  private _fontFamily: string;
+  private _disabled: boolean;
+
+  constructor(opts: DictationEditorOptions = {}) {
+    this._fontFamily = opts.fontFamily ?? "monospace";
+    this._disabled = opts.disabled ?? false;
+    this.callbacks = opts.callbacks ?? {};
+
+    const doc = opts.initialDoc ?? "";
+    const state = EditorState.create({
+      doc,
+      extensions: this.buildExtensions(this._fontFamily, this._disabled),
+    });
+    this.view = new EditorView({ state });
+    this._dictationAnchor = doc.length;
+  }
+
+  // --- Lifecycle ---
+
+  /** Mount the editor into a DOM container. */
+  attach(container: HTMLElement): void {
+    if (!this.view) return;
+    container.appendChild(this.view.dom);
+  }
+
+  /** Destroy the editor view and release resources. */
+  destroy(): void {
+    this.view?.destroy();
+    this.view = undefined;
+  }
+
+  /** Whether the controller has a live EditorView. */
+  get alive(): boolean {
+    return this.view !== undefined;
+  }
+
+  // --- External setters (driven by Svelte props / tests) ---
+
+  /** Replace the entire document content (external sync). */
+  setText(newText: string): void {
+    if (!this.view || this.updatingFromCM) return;
+    const currentDoc = this.view.state.doc.toString();
+    if (newText === currentDoc) return;
+    this.updatingFromExternal = true;
+    this.view.dispatch({
+      changes: { from: 0, to: this.view.state.doc.length, insert: newText },
+    });
+    this.updatingFromExternal = false;
+  }
+
+  /** Update the font family (reconfigures CM6 theme compartment). */
+  setFontFamily(font: string): void {
+    if (!this.view) return;
+    this._fontFamily = font;
+    this.view.dispatch({
+      effects: this.themeCompartment.reconfigure(this.buildTheme(font)),
+    });
+  }
+
+  /** Toggle editable state (reconfigures CM6 editable compartment). */
+  setDisabled(disabled: boolean): void {
+    if (!this.view) return;
+    this._disabled = disabled;
+    this.view.dispatch({
+      effects: this.editableCompartment.reconfigure(
+        EditorView.editable.of(!disabled),
+      ),
+    });
+  }
+
+  /** Replace the callback bag (e.g. when Svelte props change). */
+  setCallbacks(cb: DictationEditorCallbacks): void {
+    this.callbacks = cb;
+  }
+
+  // --- Dictation anchor ---
+
+  get dictationAnchor(): number {
+    return this._dictationAnchor;
+  }
+
+  // --- Public API (matches the 15 exports from DictationEditor.svelte) ---
+
+  insertInterim(newInterim: string): void {
+    if (!this.view) return;
+    this.updatingFromExternal = true;
+    this._dictationAnchor = doInsertInterim(
+      { view: this.view, anchor: this._dictationAnchor },
+      newInterim,
+    );
+    this.updatingFromExternal = false;
+  }
+
+  commitInterim(): { text: string; from: number; to: number } | null {
+    if (!this.view) return null;
+    this.updatingFromExternal = true;
+    const result = doCommitInterim(this.view);
+    this.updatingFromExternal = false;
+    if (result) {
+      this._dictationAnchor = result.newAnchor;
+      return { text: result.text, from: result.from, to: result.to };
+    }
+    return null;
+  }
+
+  finalizeInterim(finalText: string): void {
+    if (!this.view) return;
+    this.updatingFromExternal = true;
+    this._dictationAnchor = doFinalizeInterim(
+      { view: this.view, anchor: this._dictationAnchor },
+      finalText,
+    );
+    this.updatingFromExternal = false;
+  }
+
+  getCommittedText(): string {
+    if (!this.view) return "";
+    return doGetCommittedText(this.view);
+  }
+
+  getAnchor(): number {
+    return this._dictationAnchor;
+  }
+
+  isInsertingAtCursor(): boolean {
+    if (!this.view) return false;
+    return doIsInsertingAtCursor(this.view, this._dictationAnchor);
+  }
+
+  setCursorEnd(): void {
+    if (!this.view) return;
+    const len = this.view.state.doc.length;
+    this.view.dispatch({
+      selection: { anchor: len },
+      scrollIntoView: true,
+    });
+    this._dictationAnchor = len;
+  }
+
+  focus(): void {
+    this.view?.focus();
+  }
+
+  focusAtEnd(): void {
+    if (!this.view) return;
+    const len = this.view.state.doc.length;
+    this.view.dispatch({
+      selection: { anchor: len },
+      scrollIntoView: true,
+    });
+    this._dictationAnchor = len;
+    this.view.focus();
+  }
+
+  scrollToBottom(): void {
+    if (!this.view) return;
+    this.view.dispatch({ scrollIntoView: true });
+  }
+
+  resetAnchorToEnd(): void {
+    if (!this.view) return;
+    this._dictationAnchor = this.view.state.doc.length;
+  }
+
+  snapAnchorToEnd(): void {
+    if (!this.view) return;
+    const len = this.view.state.doc.length;
+    this._dictationAnchor = len;
+    this.view.dispatch({
+      selection: { anchor: len },
+    });
+  }
+
+  getDocLength(): number {
+    return this.view?.state.doc.length ?? 0;
+  }
+
+  hasInterim(): boolean {
+    if (!this.view) return false;
+    return this.view.state.field(interimField) !== null;
+  }
+
+  /** Get the full document text (includes interim). */
+  getText(): string {
+    return this.view?.state.doc.toString() ?? "";
+  }
+
+  // --- Internal ---
+
+  private buildTheme(font: string): Extension {
+    return EditorView.theme({
+      "&": {
+        fontSize: "14px",
+        height: "100%",
+        flex: "1",
+      },
+      "&.cm-focused": {
+        outline: "none",
+      },
+      ".cm-content": {
+        fontFamily: font,
+        lineHeight: "1.5",
+        padding: "10px",
+        caretColor: "var(--text-primary)",
+        minHeight: "100%",
+      },
+      ".cm-scroller": {
+        overflow: "auto",
+        height: "100%",
+      },
+      ".cm-line": {
+        padding: "0",
+      },
+      "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+        backgroundColor:
+          "color-mix(in srgb, var(--accent) 20%, transparent) !important",
+      },
+      ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: "var(--text-primary)",
+      },
+      ".interim-text": {
+        color: "var(--accent)",
+        opacity: "0.75",
+        fontStyle: "italic",
+        borderBottom: "1px dotted var(--accent)",
+      },
+    });
+  }
+
+  private buildExtensions(font: string, disabled: boolean): Extension[] {
+    return [
+      this.themeCompartment.of(this.buildTheme(font)),
+      ...interimExtensions(),
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      EditorView.lineWrapping,
+      this.editableCompartment.of(EditorView.editable.of(!disabled)),
+      EditorView.updateListener.of((update) => {
+        if (this.updatingFromExternal) return;
+        if (update.docChanged) {
+          this.updatingFromCM = true;
+          this.callbacks.onDocChange?.(update.state.doc.toString());
+          this.updatingFromCM = false;
+        }
+        if (update.selectionSet && !update.docChanged) {
+          const st = update.state;
+          const range = st.field(interimField);
+          if (range) {
+            this.autoCommitOnCursorMove(st);
+          } else {
+            this._dictationAnchor = st.selection.main.head;
+          }
+        }
+      }),
+    ];
+  }
+
+  private autoCommitOnCursorMove(state: EditorState): void {
+    const range = state.field(interimField);
+    if (!range) return;
+    const cursor = state.selection.main.head;
+    if (cursor >= range.from && cursor <= range.to) return;
+    this.commitInterim();
+    this.callbacks.onInterimCommit?.();
+    this._dictationAnchor = cursor;
+  }
+}

--- a/src/test/dictationEditorController.test.ts
+++ b/src/test/dictationEditorController.test.ts
@@ -1,0 +1,529 @@
+// ---------------------------------------------------------------------------
+// Unit tests for DictationEditorController.
+//
+// These cover the orchestration layer that was previously untestable inside
+// DictationEditor.svelte:
+//   R1  Bidirectional text sync (setText / onDocChange, feedback-loop guards)
+//   R2  Interim text lifecycle (insert → replace → commit / finalize)
+//   R3  Dictation anchor tracking (cursor click, reset, snap, isInsertingAtCursor)
+//   R4  Committed text extraction
+//   R5  Dynamic theming (font change via compartment)
+//   R6  Editable / disabled toggle
+//   R9  Callbacks (onDocChange, onInterimCommit)
+//   R10 Programmatic cursor/focus methods
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from "vitest";
+import { DictationEditorController, type DictationEditorCallbacks } from "../lib/DictationEditorController";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function create(doc = "", callbacks?: DictationEditorCallbacks) {
+  return new DictationEditorController({
+    initialDoc: doc,
+    fontFamily: "monospace",
+    disabled: false,
+    callbacks,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// R1 — Bidirectional text binding
+// ---------------------------------------------------------------------------
+
+describe("R1: Bidirectional text sync", () => {
+  it("initialises with the provided document", () => {
+    const ctrl = create("Hello");
+    expect(ctrl.getText()).toBe("Hello");
+    expect(ctrl.getDocLength()).toBe(5);
+    ctrl.destroy();
+  });
+
+  it("setText replaces doc content", () => {
+    const ctrl = create("old");
+    ctrl.setText("new text");
+    expect(ctrl.getText()).toBe("new text");
+    ctrl.destroy();
+  });
+
+  it("setText is a no-op when text matches", () => {
+    const ctrl = create("same");
+    ctrl.setText("same"); // Should not throw or cause issues
+    expect(ctrl.getText()).toBe("same");
+    ctrl.destroy();
+  });
+
+  it("setText does not trigger onDocChange (no feedback loop)", () => {
+    const onDocChange = vi.fn();
+    const ctrl = create("start", { onDocChange });
+    ctrl.setText("updated");
+    expect(onDocChange).not.toHaveBeenCalled();
+    ctrl.destroy();
+  });
+
+  it("defaults to empty document when no initialDoc", () => {
+    const ctrl = new DictationEditorController();
+    expect(ctrl.getText()).toBe("");
+    expect(ctrl.getDocLength()).toBe(0);
+    ctrl.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R2 — Interim text lifecycle
+// ---------------------------------------------------------------------------
+
+describe("R2: Interim text lifecycle", () => {
+  it("insertInterim adds decorated text at anchor", () => {
+    const ctrl = create();
+    ctrl.insertInterim("Hello");
+    expect(ctrl.getText()).toBe("Hello");
+    expect(ctrl.hasInterim()).toBe(true);
+    ctrl.destroy();
+  });
+
+  it("insertInterim prepends space when needed", () => {
+    const ctrl = create("Hello.");
+    // Anchor starts at doc end (6)
+    ctrl.insertInterim("World");
+    expect(ctrl.getText()).toBe("Hello. World");
+    expect(ctrl.hasInterim()).toBe(true);
+    ctrl.destroy();
+  });
+
+  it("insertInterim replaces existing interim", () => {
+    const ctrl = create("Hi.");
+    ctrl.insertInterim("there");
+    expect(ctrl.getText()).toBe("Hi. there");
+
+    ctrl.insertInterim("there folks");
+    expect(ctrl.getText()).toBe("Hi. there folks");
+    expect(ctrl.hasInterim()).toBe(true);
+    ctrl.destroy();
+  });
+
+  it("insertInterim with empty string and no range is a no-op", () => {
+    const ctrl = create("Hello");
+    ctrl.insertInterim("");
+    expect(ctrl.getText()).toBe("Hello");
+    expect(ctrl.hasInterim()).toBe(false);
+    ctrl.destroy();
+  });
+
+  it("commitInterim clears decoration, text stays", () => {
+    const ctrl = create("A.");
+    ctrl.insertInterim("B");
+    expect(ctrl.hasInterim()).toBe(true);
+
+    const result = ctrl.commitInterim();
+    expect(result).toEqual({ text: "B", from: 3, to: 4 });
+    expect(ctrl.getText()).toBe("A. B");
+    expect(ctrl.hasInterim()).toBe(false);
+    ctrl.destroy();
+  });
+
+  it("commitInterim returns null when no interim", () => {
+    const ctrl = create("text");
+    expect(ctrl.commitInterim()).toBeNull();
+    ctrl.destroy();
+  });
+
+  it("finalizeInterim replaces interim with final text", () => {
+    const ctrl = create("Hello.");
+    ctrl.insertInterim("wrld");
+    expect(ctrl.getText()).toBe("Hello. wrld");
+
+    ctrl.finalizeInterim("world!");
+    expect(ctrl.getText()).toBe("Hello. world!");
+    expect(ctrl.hasInterim()).toBe(false);
+    ctrl.destroy();
+  });
+
+  it("finalizeInterim inserts at anchor when no interim range", () => {
+    const ctrl = create("Hello.");
+    ctrl.finalizeInterim("World");
+    expect(ctrl.getText()).toBe("Hello. World");
+    expect(ctrl.hasInterim()).toBe(false);
+    ctrl.destroy();
+  });
+
+  it("multi-segment flow without duplication", () => {
+    const ctrl = create();
+
+    // Segment 1
+    ctrl.insertInterim("Hello");
+    ctrl.insertInterim("Hello world");
+    ctrl.finalizeInterim("Hello world.");
+    expect(ctrl.getText()).toBe("Hello world.");
+
+    // Segment 2
+    ctrl.insertInterim("This");
+    expect(ctrl.getText()).toBe("Hello world. This");
+    ctrl.finalizeInterim("This is great.");
+    expect(ctrl.getText()).toBe("Hello world. This is great.");
+
+    // Segment 3
+    ctrl.insertInterim("End");
+    ctrl.finalizeInterim("End.");
+    expect(ctrl.getText()).toBe("Hello world. This is great. End.");
+
+    ctrl.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 — Dictation anchor tracking
+// ---------------------------------------------------------------------------
+
+describe("R3: Dictation anchor tracking", () => {
+  it("initial anchor is at doc end", () => {
+    const ctrl = create("Hello");
+    expect(ctrl.dictationAnchor).toBe(5);
+    ctrl.destroy();
+  });
+
+  it("anchor advances after finalizeInterim", () => {
+    const ctrl = create("Hi.");
+    // anchor = 3
+    ctrl.finalizeInterim("Bye");
+    // "Hi. Bye" → anchor should be at end of "Bye" = 7
+    expect(ctrl.dictationAnchor).toBe(7);
+    ctrl.destroy();
+  });
+
+  it("anchor advances after commitInterim", () => {
+    const ctrl = create("A.");
+    ctrl.insertInterim("B");
+    const result = ctrl.commitInterim();
+    expect(ctrl.dictationAnchor).toBe(result!.to); // 4
+    ctrl.destroy();
+  });
+
+  it("resetAnchorToEnd sets anchor to doc end", () => {
+    const ctrl = create("Hello world.");
+    // Simulate anchor being somewhere in the middle by doing mid-text work
+    ctrl.setText("Hello world. More text.");
+    ctrl.resetAnchorToEnd();
+    expect(ctrl.dictationAnchor).toBe(ctrl.getDocLength());
+    ctrl.destroy();
+  });
+
+  it("snapAnchorToEnd sets anchor and cursor to doc end", () => {
+    const ctrl = create("Hello");
+    ctrl.snapAnchorToEnd();
+    expect(ctrl.dictationAnchor).toBe(5);
+    ctrl.destroy();
+  });
+
+  it("isInsertingAtCursor returns false when anchor is at end", () => {
+    const ctrl = create("Hello");
+    expect(ctrl.isInsertingAtCursor()).toBe(false);
+    ctrl.destroy();
+  });
+
+  it("isInsertingAtCursor returns false on destroyed controller", () => {
+    const ctrl = create("Hello");
+    ctrl.destroy();
+    expect(ctrl.isInsertingAtCursor()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 — Committed text extraction
+// ---------------------------------------------------------------------------
+
+describe("R4: Committed text extraction", () => {
+  it("returns full text when no interim", () => {
+    const ctrl = create("Hello world.");
+    expect(ctrl.getCommittedText()).toBe("Hello world.");
+    ctrl.destroy();
+  });
+
+  it("strips interim text", () => {
+    const ctrl = create("Hello.");
+    ctrl.insertInterim("World");
+    // Doc: "Hello. World", interim is "World" — committed includes separator space
+    expect(ctrl.getCommittedText()).toBe("Hello. ");
+    ctrl.destroy();
+  });
+
+  it("returns full text after finalize", () => {
+    const ctrl = create("Hello.");
+    ctrl.insertInterim("World");
+    ctrl.finalizeInterim("World!");
+    expect(ctrl.getCommittedText()).toBe("Hello. World!");
+    ctrl.destroy();
+  });
+
+  it("returns empty string on destroyed controller", () => {
+    const ctrl = create("Hello");
+    ctrl.destroy();
+    expect(ctrl.getCommittedText()).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R5 — Dynamic theming (font change)
+// ---------------------------------------------------------------------------
+
+describe("R5: Dynamic theming", () => {
+  it("setFontFamily does not throw and controller stays alive", () => {
+    const ctrl = create("text");
+    expect(() => ctrl.setFontFamily("'Georgia', serif")).not.toThrow();
+    expect(ctrl.alive).toBe(true);
+    expect(ctrl.getText()).toBe("text");
+    ctrl.destroy();
+  });
+
+  it("setFontFamily on destroyed controller is a no-op", () => {
+    const ctrl = create();
+    ctrl.destroy();
+    expect(() => ctrl.setFontFamily("serif")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R6 — Editable / disabled toggle
+// ---------------------------------------------------------------------------
+
+describe("R6: Editable / disabled toggle", () => {
+  it("setDisabled does not throw and controller stays alive", () => {
+    const ctrl = create("text");
+    expect(() => ctrl.setDisabled(true)).not.toThrow();
+    expect(ctrl.alive).toBe(true);
+
+    expect(() => ctrl.setDisabled(false)).not.toThrow();
+    expect(ctrl.alive).toBe(true);
+    ctrl.destroy();
+  });
+
+  it("can be created in disabled state", () => {
+    const ctrl = new DictationEditorController({
+      initialDoc: "readonly",
+      disabled: true,
+    });
+    expect(ctrl.getText()).toBe("readonly");
+    ctrl.destroy();
+  });
+
+  it("setDisabled on destroyed controller is a no-op", () => {
+    const ctrl = create();
+    ctrl.destroy();
+    expect(() => ctrl.setDisabled(true)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R9 — Callbacks
+// ---------------------------------------------------------------------------
+
+describe("R9: Callbacks", () => {
+  it("setCallbacks replaces callbacks", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const ctrl = create("", { onInterimCommit: first });
+    ctrl.setCallbacks({ onInterimCommit: second });
+
+    // The new callback should be used.  We can't easily trigger a cursor-move
+    // commit in jsdom, but we can verify setCallbacks doesn't throw and the
+    // controller is still functional.
+    expect(ctrl.alive).toBe(true);
+    ctrl.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R10 — Programmatic cursor / focus methods
+// ---------------------------------------------------------------------------
+
+describe("R10: Programmatic cursor/focus", () => {
+  it("setCursorEnd moves anchor to doc end", () => {
+    const ctrl = create("Hello world.");
+    // Force anchor to 0 by creating fresh controller with empty doc then setting text
+    const ctrl2 = create();
+    ctrl2.setText("Hello world.");
+    // anchor is still 0 from initial empty doc
+    expect(ctrl2.dictationAnchor).toBe(0);
+    ctrl2.setCursorEnd();
+    expect(ctrl2.dictationAnchor).toBe(12);
+    ctrl.destroy();
+    ctrl2.destroy();
+  });
+
+  it("focusAtEnd moves anchor to doc end", () => {
+    const ctrl = create();
+    ctrl.setText("ABC");
+    ctrl.focusAtEnd();
+    expect(ctrl.dictationAnchor).toBe(3);
+    ctrl.destroy();
+  });
+
+  it("scrollToBottom does not throw", () => {
+    const ctrl = create("some text\nwith lines\n");
+    expect(() => ctrl.scrollToBottom()).not.toThrow();
+    ctrl.destroy();
+  });
+
+  it("focus does not throw", () => {
+    const ctrl = create("text");
+    expect(() => ctrl.focus()).not.toThrow();
+    ctrl.destroy();
+  });
+
+  it("getDocLength returns document length", () => {
+    const ctrl = create("12345");
+    expect(ctrl.getDocLength()).toBe(5);
+    ctrl.setText("123456789");
+    expect(ctrl.getDocLength()).toBe(9);
+    ctrl.destroy();
+  });
+
+  it("getDocLength returns 0 on destroyed controller", () => {
+    const ctrl = create("text");
+    ctrl.destroy();
+    expect(ctrl.getDocLength()).toBe(0);
+  });
+
+  it("methods are no-ops on destroyed controller", () => {
+    const ctrl = create("text");
+    ctrl.destroy();
+    expect(() => ctrl.setCursorEnd()).not.toThrow();
+    expect(() => ctrl.focusAtEnd()).not.toThrow();
+    expect(() => ctrl.scrollToBottom()).not.toThrow();
+    expect(() => ctrl.focus()).not.toThrow();
+    expect(() => ctrl.resetAnchorToEnd()).not.toThrow();
+    expect(() => ctrl.snapAnchorToEnd()).not.toThrow();
+    expect(() => ctrl.insertInterim("x")).not.toThrow();
+    expect(ctrl.commitInterim()).toBeNull();
+    expect(() => ctrl.finalizeInterim("x")).not.toThrow();
+    expect(ctrl.hasInterim()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe("Lifecycle", () => {
+  it("alive is true after creation, false after destroy", () => {
+    const ctrl = create("text");
+    expect(ctrl.alive).toBe(true);
+    ctrl.destroy();
+    expect(ctrl.alive).toBe(false);
+  });
+
+  it("attach mounts the editor into a DOM element", () => {
+    const ctrl = create("Hello");
+    const container = document.createElement("div");
+    ctrl.attach(container);
+    // CM6 renders a .cm-editor element
+    expect(container.querySelector(".cm-editor")).not.toBeNull();
+    ctrl.destroy();
+  });
+
+  it("double destroy is safe", () => {
+    const ctrl = create();
+    ctrl.destroy();
+    expect(() => ctrl.destroy()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: End-to-end dictation session through controller
+// ---------------------------------------------------------------------------
+
+describe("End-to-end dictation session", () => {
+  it("simulates a full recording → stop → copy flow", () => {
+    const ctrl = create();
+
+    // User opens popup — empty editor
+    expect(ctrl.getText()).toBe("");
+    expect(ctrl.dictationAnchor).toBe(0);
+
+    // Speech starts: interim results arrive
+    ctrl.insertInterim("Hello");
+    expect(ctrl.getText()).toBe("Hello");
+    expect(ctrl.hasInterim()).toBe(true);
+
+    ctrl.insertInterim("Hello world");
+    expect(ctrl.getText()).toBe("Hello world");
+
+    // Provider sends final
+    ctrl.finalizeInterim("Hello world.");
+    expect(ctrl.getText()).toBe("Hello world.");
+    expect(ctrl.hasInterim()).toBe(false);
+    expect(ctrl.dictationAnchor).toBe(12);
+
+    // Second segment
+    ctrl.insertInterim("How");
+    ctrl.insertInterim("How are you");
+    ctrl.finalizeInterim("How are you?");
+    expect(ctrl.getText()).toBe("Hello world. How are you?");
+    expect(ctrl.dictationAnchor).toBe(25);
+
+    // Recording stops — committed text for copy
+    expect(ctrl.getCommittedText()).toBe("Hello world. How are you?");
+
+    // User closes popup
+    ctrl.destroy();
+  });
+
+  it("simulates user edit during recording (commit-on-edit)", () => {
+    const ctrl = create();
+
+    // First segment finalized
+    ctrl.insertInterim("First");
+    ctrl.finalizeInterim("First.");
+    expect(ctrl.getText()).toBe("First.");
+
+    // Second segment starts
+    ctrl.insertInterim("Second");
+    expect(ctrl.getText()).toBe("First. Second");
+    expect(ctrl.hasInterim()).toBe(true);
+
+    // User manually commits (simulating what happens on user edit)
+    ctrl.commitInterim();
+    expect(ctrl.hasInterim()).toBe(false);
+    expect(ctrl.getText()).toBe("First. Second");
+
+    // Third segment
+    ctrl.insertInterim("Third");
+    expect(ctrl.getText()).toBe("First. Second Third");
+    ctrl.finalizeInterim("Third.");
+    expect(ctrl.getText()).toBe("First. Second Third.");
+
+    ctrl.destroy();
+  });
+
+  it("simulates resetAnchorToEnd before new recording session", () => {
+    const ctrl = create("Previous text from last session.");
+    ctrl.resetAnchorToEnd();
+    expect(ctrl.dictationAnchor).toBe(32);
+
+    ctrl.insertInterim("New");
+    expect(ctrl.getText()).toBe("Previous text from last session. New");
+    ctrl.finalizeInterim("New session.");
+    expect(ctrl.getText()).toBe("Previous text from last session. New session.");
+
+    ctrl.destroy();
+  });
+
+  it("simulates setText (template apply) then recording", () => {
+    const ctrl = create();
+
+    // Apply template
+    ctrl.setText("Template: {{topic}}\n\n");
+    ctrl.setCursorEnd();
+    expect(ctrl.dictationAnchor).toBe(21);
+
+    // Start recording
+    ctrl.insertInterim("My notes");
+    expect(ctrl.getText()).toBe("Template: {{topic}}\n\nMy notes");
+    ctrl.finalizeInterim("My notes about AI.");
+    expect(ctrl.getText()).toBe("Template: {{topic}}\n\nMy notes about AI.");
+
+    ctrl.destroy();
+  });
+});


### PR DESCRIPTION
Closes #12

## What

Extract a headless `DictationEditorController` class from `DictationEditor.svelte` to make the editor's orchestration logic unit-testable.

## Changes

### New: `src/lib/DictationEditorController.ts`
Headless TypeScript class that owns:
- `EditorView` instance + CM6 compartments (theme, editable)
- Dictation anchor tracking (follows cursor, advances on insert/finalize)
- Feedback-loop guards (`updatingFromExternal` / `updatingFromCM`)
- Auto-commit on cursor move (same logic that was in the Svelte component)
- All 15 public methods previously exported from the Svelte component

### Refactored: `src/components/popup/DictationEditor.svelte`
Reduced from ~320 lines to ~130 lines. Now a thin shell that:
- Creates the controller in `onMount`, attaches to container
- Forwards prop changes (`text`, `fontFamily`, `disabled`) via `$effect`
- Delegates all exported functions to controller methods
- **Public API is identical** — `Popup.svelte` needs zero changes

### New: `src/test/dictationEditorController.test.ts`
45 unit tests organized by requirement:

| Requirement | Tests | Previously covered? |
|---|---|---|
| R1: Bidirectional text sync | 5 | No |
| R2: Interim lifecycle | 9 | Pure logic only |
| R3: Anchor tracking | 7 | Partial |
| R4: Committed text extraction | 4 | Pure logic only |
| R5: Dynamic theming | 2 | No |
| R6: Disabled toggle | 3 | No |
| R9: Callbacks | 1 | No |
| R10: Cursor/focus methods | 7 | No |
| Lifecycle | 3 | No |
| End-to-end flows | 4 | No |

## Verification

- `npx vitest run` → **506 tests pass** (35 files, 0 failures)
- `npx svelte-check` → **0 errors, 0 warnings**
- Manual testing needed: full dictation flow, interim decoration, cursor tracking, font switch, undo/redo, disabled during enhance