### PR TITLE
feat: Add native speech providers for Apple (macOS) and Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,10 +8,14 @@ version = "1.0.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "block2",
  "chrono",
  "futures-util",
  "objc2",
  "objc2-app-kit",
+ "objc2-avf-audio",
+ "objc2-foundation",
+ "objc2-speech",
  "reqwest",
  "rmcp",
  "serde",
@@ -29,6 +33,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows",
  "zip",
 ]
 
@@ -2747,6 +2752,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-core-audio-types",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2786,28 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -2800,6 +2853,20 @@ checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
 ]
 
 [[package]]
@@ -2850,6 +2917,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2874,6 +2942,19 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-speech"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eb609f9d2a25e0f8b76954f3acaa58348ce2a91285fe867643b2224ac4d263"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-media",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,3 +42,15 @@ axum = "0.8"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSRunningApplication"] }
+objc2-foundation = { version = "0.3", features = ["NSString", "NSArray", "NSLocale", "NSError", "NSObjCRuntime"] }
+objc2-speech = { version = "0.3", features = ["SFSpeechRecognizer", "SFSpeechRecognitionTask", "SFSpeechRecognitionResult", "SFSpeechRecognitionRequest", "SFTranscription", "SFTranscriptionSegment"] }
+objc2-avf-audio = { version = "0.3", features = ["AVAudioEngine", "AVAudioNode", "AVAudioIONode", "AVAudioFormat", "AVAudioBuffer", "AVAudioTime", "block2"] }
+block2 = "0.6"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = [
+    "Media_SpeechRecognition",
+    "Globalization",
+    "Foundation",
+    "Foundation_Collections",
+] }

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>Developer Voice to Prompt needs microphone access for speech-to-text dictation.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Developer Voice to Prompt uses Apple Speech Recognition for native on-device dictation.</string>
     <key>LSUIElement</key>
     <true/>
 </dict>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,21 @@ pub fn run() {
                 }
             }
 
+            // Register platform-specific native speech providers
+            {
+                let registry = app.state::<speech::NativeSpeechRegistry>();
+                #[cfg(target_os = "macos")]
+                {
+                    registry.register(Box::new(speech::apple::AppleSpeechProvider::new()));
+                    tracing::info!("Registered Apple Speech native provider");
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    registry.register(Box::new(speech::windows::WindowsSpeechProvider::new()));
+                    tracing::info!("Registered Windows Speech native provider");
+                }
+            }
+
             // Apply Dock (macOS) / Taskbar (Windows) visibility from saved settings
             commands::set_dock_visibility(app.handle(), user_settings.show_in_dock);
 

--- a/src-tauri/src/speech/apple.rs
+++ b/src-tauri/src/speech/apple.rs
@@ -1,0 +1,304 @@
+// ---------------------------------------------------------------------------
+// Apple Speech provider — macOS SFSpeechRecognizer + AVAudioEngine
+// ---------------------------------------------------------------------------
+//
+// Uses Apple's Speech framework for on-device and cloud-based speech
+// recognition. Audio is captured via AVAudioEngine's input node and fed
+// to SFSpeechAudioBufferRecognitionRequest for real-time transcription.
+//
+// Threading: All ObjC objects are created and used on a dedicated background
+// thread with its own run loop. The `SpeechEmitter` (which is Send+Sync via
+// Tauri's AppHandle) is cloned into the result handler block.
+// ---------------------------------------------------------------------------
+
+use super::{NativeSpeechProvider, SpeechEmitter};
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Bool};
+use objc2::{msg_send, AllocAnyThread};
+use objc2_avf_audio::{AVAudioEngine, AVAudioPCMBuffer, AVAudioTime};
+use objc2_foundation::{NSLocale, NSString};
+use objc2_speech::{
+    SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
+    SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
+};
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex};
+
+// ---------------------------------------------------------------------------
+// Inner state — held behind Arc<Mutex<>> so the ObjC blocks can access it
+// ---------------------------------------------------------------------------
+
+struct InnerState {
+    engine: Retained<AVAudioEngine>,
+    task: Retained<SFSpeechRecognitionTask>,
+    request: Retained<SFSpeechAudioBufferRecognitionRequest>,
+}
+
+// Safety: AVAudioEngine, SFSpeechRecognitionTask, and
+// SFSpeechAudioBufferRecognitionRequest are documented as safe to use from
+// background threads. The objc2 crate is conservative about Send for ObjC
+// types, but Apple's documentation explicitly allows cross-thread usage of
+// these classes.
+unsafe impl Send for InnerState {}
+
+// ---------------------------------------------------------------------------
+// AppleSpeechProvider
+// ---------------------------------------------------------------------------
+
+pub struct AppleSpeechProvider {
+    state: Arc<Mutex<Option<InnerState>>>,
+}
+
+impl AppleSpeechProvider {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl NativeSpeechProvider for AppleSpeechProvider {
+    fn id(&self) -> &str {
+        "apple"
+    }
+
+    fn start(
+        &mut self,
+        config: serde_json::Value,
+        emitter: SpeechEmitter,
+    ) -> Result<(), String> {
+        // Stop any existing session first
+        self.stop().ok();
+
+        let language = config
+            .get("language")
+            .and_then(|v| v.as_str())
+            .unwrap_or("en-US");
+
+        let on_device = config
+            .get("on_device")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Check authorization status
+        let auth_status = unsafe { SFSpeechRecognizer::authorizationStatus() };
+        if auth_status == SFSpeechRecognizerAuthorizationStatus::Denied
+            || auth_status == SFSpeechRecognizerAuthorizationStatus::Restricted
+        {
+            return Err(
+                "Speech recognition permission denied. Grant access in System Settings → Privacy & Security → Speech Recognition.".into(),
+            );
+        }
+
+        // If not determined, request authorization
+        if auth_status == SFSpeechRecognizerAuthorizationStatus::NotDetermined {
+            let (tx, rx) = std::sync::mpsc::channel();
+            let block = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+                let _ = tx.send(status);
+            });
+            unsafe {
+                SFSpeechRecognizer::requestAuthorization(&block);
+            }
+            match rx.recv_timeout(std::time::Duration::from_secs(30)) {
+                Ok(status) if status == SFSpeechRecognizerAuthorizationStatus::Authorized => {}
+                Ok(_) => {
+                    return Err("Speech recognition authorization was denied.".into());
+                }
+                Err(_) => {
+                    return Err("Speech recognition authorization timed out.".into());
+                }
+            }
+        }
+
+        // Create recognizer with locale
+        let locale_str = NSString::from_str(language);
+        let locale = NSLocale::initWithLocaleIdentifier(NSLocale::alloc(), &locale_str);
+        let recognizer = unsafe {
+            SFSpeechRecognizer::initWithLocale(SFSpeechRecognizer::alloc(), &locale)
+        }
+        .ok_or_else(|| format!("Failed to create speech recognizer for locale: {language}"))?;
+
+        let is_available: Bool = unsafe { msg_send![&recognizer, isAvailable] };
+        if !is_available.as_bool() {
+            return Err(format!(
+                "Speech recognition is not available for language: {language}"
+            ));
+        }
+
+        // Create recognition request
+        let request = unsafe {
+            SFSpeechAudioBufferRecognitionRequest::init(
+                SFSpeechAudioBufferRecognitionRequest::alloc(),
+            )
+        };
+        unsafe {
+            let _: () = msg_send![&request, setShouldReportPartialResults: Bool::YES];
+        }
+
+        // Set on-device recognition if requested
+        if on_device {
+            unsafe {
+                let supports: Bool = msg_send![&recognizer, supportsOnDeviceRecognition];
+                if supports.as_bool() {
+                    let _: () =
+                        msg_send![&request, setRequiresOnDeviceRecognition: Bool::YES];
+                } else {
+                    tracing::warn!("On-device recognition not supported for {language}, using cloud");
+                }
+            }
+        }
+
+        // Create audio engine
+        let engine = unsafe { AVAudioEngine::init(AVAudioEngine::alloc()) };
+
+        // Get input node and its output format
+        let input_node = unsafe { engine.inputNode() };
+        let format: Retained<AnyObject> = unsafe {
+            msg_send![&input_node, outputFormatForBus: 0u32]
+        };
+
+        // Install tap on input node to feed audio to the recognition request
+        let request_for_tap = request.clone();
+        let tap_block = RcBlock::new(
+            move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
+                unsafe {
+                    let _: () = msg_send![&request_for_tap, appendAudioPCMBuffer: buffer.as_ptr()];
+                }
+            },
+        );
+        unsafe {
+            let _: () = msg_send![
+                &input_node,
+                installTapOnBus: 0u32,
+                bufferSize: 1024u32,
+                format: &*format,
+                block: &*tap_block
+            ];
+        }
+
+        // Prepare and start engine
+        unsafe {
+            let _: () = msg_send![&engine, prepare];
+        }
+        let mut error_ptr: *mut objc2_foundation::NSError = std::ptr::null_mut();
+        let started: Bool = unsafe {
+            msg_send![&engine, startAndReturnError: &mut error_ptr]
+        };
+        if !started.as_bool() {
+            let err_msg = if !error_ptr.is_null() {
+                unsafe {
+                    let desc: Retained<NSString> =
+                        msg_send![error_ptr, localizedDescription];
+                    desc.to_string()
+                }
+            } else {
+                "Unknown error starting audio engine".into()
+            };
+            return Err(format!("Failed to start audio engine: {err_msg}"));
+        }
+
+        // Start recognition task with result handler
+        let emitter_for_block = emitter.clone();
+        let state_for_block = Arc::clone(&self.state);
+        let result_block = RcBlock::new(
+            move |result: *mut SFSpeechRecognitionResult,
+                  error: *mut objc2_foundation::NSError| {
+                if !error.is_null() {
+                    let err_msg: String = unsafe {
+                        let desc: Retained<NSString> =
+                            msg_send![error, localizedDescription];
+                        desc.to_string()
+                    };
+                    // Ignore cancellation errors (triggered by stop())
+                    if !err_msg.contains("cancelled") && !err_msg.contains("Canceled") {
+                        emitter_for_block.error(&err_msg);
+                        emitter_for_block.status("error");
+                    }
+                    return;
+                }
+                if result.is_null() {
+                    return;
+                }
+                unsafe {
+                    let is_final: Bool = msg_send![result, isFinal];
+                    let transcription: Retained<AnyObject> =
+                        msg_send![result, bestTranscription];
+                    let text: Retained<NSString> =
+                        msg_send![&*transcription, formattedString];
+                    let text_str = text.to_string();
+
+                    if !text_str.is_empty() {
+                        if is_final.as_bool() {
+                            emitter_for_block.final_text(&text_str);
+                        } else {
+                            emitter_for_block.interim(&text_str);
+                        }
+                    }
+
+                    if is_final.as_bool() {
+                        let mut guard = state_for_block.lock().unwrap();
+                        *guard = None;
+                        emitter_for_block.status("idle");
+                    }
+                }
+            },
+        );
+
+        let task: Retained<SFSpeechRecognitionTask> = unsafe {
+            msg_send![
+                &recognizer,
+                recognitionTaskWithRequest: &*request,
+                resultHandler: &*result_block
+            ]
+        };
+
+        // Store state
+        {
+            let mut guard = self.state.lock().map_err(|e| e.to_string())?;
+            *guard = Some(InnerState {
+                engine,
+                task,
+                request,
+            });
+        }
+
+        emitter.status("listening");
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), String> {
+        let mut guard = self.state.lock().map_err(|e| e.to_string())?;
+        if let Some(inner) = guard.take() {
+            unsafe {
+                let input_node = inner.engine.inputNode();
+                let _: () = msg_send![&input_node, removeTapOnBus: 0u32];
+                inner.engine.stop();
+            }
+            unsafe {
+                let _: () = msg_send![&inner.request, endAudio];
+            }
+            unsafe {
+                inner.task.cancel();
+            }
+        }
+        Ok(())
+    }
+
+    fn is_available(&self) -> bool {
+        let auth_status = unsafe { SFSpeechRecognizer::authorizationStatus() };
+        auth_status != SFSpeechRecognizerAuthorizationStatus::Denied
+            && auth_status != SFSpeechRecognizerAuthorizationStatus::Restricted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_id() {
+        let provider = AppleSpeechProvider::new();
+        assert_eq!(provider.id(), "apple");
+    }
+}

--- a/src-tauri/src/speech/mod.rs
+++ b/src-tauri/src/speech/mod.rs
@@ -19,6 +19,11 @@
 //   speech://{provider_id}/performance   → { rtf, avgRtf, inferenceMs, backend? }
 // ---------------------------------------------------------------------------
 
+#[cfg(target_os = "macos")]
+pub mod apple;
+#[cfg(target_os = "windows")]
+pub mod windows;
+
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/src-tauri/src/speech/windows.rs
+++ b/src-tauri/src/speech/windows.rs
@@ -1,0 +1,242 @@
+// ---------------------------------------------------------------------------
+// Windows Speech provider — Windows.Media.SpeechRecognition
+// ---------------------------------------------------------------------------
+//
+// Uses the UWP SpeechRecognizer API for real-time speech-to-text on Windows.
+// Continuous recognition session with dictation grammar provides both
+// hypothesis (interim) and result (final) events.
+//
+// Threading: WinRT event handlers run on a thread pool. The SpeechEmitter
+// is cloned into each handler. The SpeechRecognizer and session are stored
+// as managed state and accessed under a Mutex.
+// ---------------------------------------------------------------------------
+
+use super::{NativeSpeechProvider, SpeechEmitter};
+use std::sync::{Arc, Mutex};
+use windows::{
+    Foundation::TypedEventHandler,
+    Globalization::Language,
+    Media::SpeechRecognition::{
+        SpeechContinuousRecognitionResultGeneratedEventArgs,
+        SpeechContinuousRecognitionSession, SpeechRecognitionResultStatus, SpeechRecognizer,
+        SpeechRecognitionTopicConstraint, SpeechRecognitionScenario,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Inner state
+// ---------------------------------------------------------------------------
+
+struct InnerState {
+    recognizer: SpeechRecognizer,
+    session: SpeechContinuousRecognitionSession,
+}
+
+// Safety: WinRT objects are apartment-agile by default and safe to send
+// between threads.
+unsafe impl Send for InnerState {}
+
+// ---------------------------------------------------------------------------
+// WindowsSpeechProvider
+// ---------------------------------------------------------------------------
+
+pub struct WindowsSpeechProvider {
+    state: Arc<Mutex<Option<InnerState>>>,
+}
+
+impl WindowsSpeechProvider {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl NativeSpeechProvider for WindowsSpeechProvider {
+    fn id(&self) -> &str {
+        "windows"
+    }
+
+    fn start(
+        &mut self,
+        config: serde_json::Value,
+        emitter: SpeechEmitter,
+    ) -> Result<(), String> {
+        // Stop any existing session first
+        self.stop().ok();
+
+        let language_tag = config
+            .get("language")
+            .and_then(|v| v.as_str())
+            .unwrap_or("en-US");
+
+        // Create recognizer with language
+        let language = Language::CreateLanguage(&language_tag.into())
+            .map_err(|e| format!("Failed to create language '{language_tag}': {e}"))?;
+        let recognizer = SpeechRecognizer::CreateWithLanguage(&language)
+            .map_err(|e| format!("Failed to create SpeechRecognizer: {e}"))?;
+
+        // Add dictation constraint for free-form speech
+        let constraint =
+            SpeechRecognitionTopicConstraint::Create(SpeechRecognitionScenario::Dictation, &"dictation".into())
+                .map_err(|e| format!("Failed to create dictation constraint: {e}"))?;
+        recognizer
+            .Constraints()
+            .map_err(|e| format!("Failed to get constraints: {e}"))?
+            .Append(&constraint)
+            .map_err(|e| format!("Failed to add constraint: {e}"))?;
+
+        // Compile constraints (synchronous via GetResults)
+        let compile_result = recognizer
+            .CompileConstraintsAsync()
+            .map_err(|e| format!("Failed to start constraint compilation: {e}"))?
+            .get()
+            .map_err(|e| format!("Constraint compilation failed: {e}"))?;
+
+        if compile_result.Status().map_err(|e| e.to_string())?
+            != SpeechRecognitionResultStatus::Success
+        {
+            return Err("Failed to compile speech recognition constraints.".into());
+        }
+
+        // Get continuous recognition session
+        let session = recognizer
+            .ContinuousRecognitionSession()
+            .map_err(|e| format!("Failed to get continuous session: {e}"))?;
+
+        // Subscribe to ResultGenerated (final results)
+        let emitter_result = emitter.clone();
+        session
+            .ResultGenerated(&TypedEventHandler::new(
+                move |_session: &Option<SpeechContinuousRecognitionSession>,
+                      args: &Option<SpeechContinuousRecognitionResultGeneratedEventArgs>| {
+                    if let Some(args) = args {
+                        if let Ok(result) = args.Result() {
+                            if let Ok(text) = result.Text() {
+                                let text_str = text.to_string_lossy();
+                                if !text_str.is_empty() {
+                                    emitter_result.final_text(&text_str);
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                },
+            ))
+            .map_err(|e| format!("Failed to register ResultGenerated handler: {e}"))?;
+
+        // Subscribe to HypothesisGenerated (interim results)
+        let emitter_hypothesis = emitter.clone();
+        recognizer
+            .HypothesisGenerated(&TypedEventHandler::new(
+                move |_recognizer: &Option<SpeechRecognizer>,
+                      args: &Option<
+                    windows::Media::SpeechRecognition::SpeechRecognitionHypothesisGeneratedEventArgs,
+                >| {
+                    if let Some(args) = args {
+                        if let Ok(hypothesis) = args.Hypothesis() {
+                            if let Ok(text) = hypothesis.Text() {
+                                let text_str = text.to_string_lossy();
+                                if !text_str.is_empty() {
+                                    emitter_hypothesis.interim(&text_str);
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                },
+            ))
+            .map_err(|e| format!("Failed to register HypothesisGenerated handler: {e}"))?;
+
+        // Subscribe to Completed for error handling
+        let emitter_completed = emitter.clone();
+        let state_for_complete = Arc::clone(&self.state);
+        session
+            .Completed(&TypedEventHandler::new(
+                move |_session: &Option<SpeechContinuousRecognitionSession>,
+                      args: &Option<
+                    windows::Media::SpeechRecognition::SpeechContinuousRecognitionCompletedEventArgs,
+                >| {
+                    if let Some(args) = args {
+                        if let Ok(status) = args.Status() {
+                            if status != SpeechRecognitionResultStatus::Success {
+                                let msg = match status {
+                                    SpeechRecognitionResultStatus::MicrophoneUnavailable => {
+                                        "Microphone is unavailable. Check your audio settings."
+                                    }
+                                    SpeechRecognitionResultStatus::NetworkFailure => {
+                                        "Network failure during speech recognition."
+                                    }
+                                    _ => "Speech recognition session ended unexpectedly.",
+                                };
+                                emitter_completed.error(msg);
+                            }
+                        }
+                    }
+                    // Clean up state
+                    if let Ok(mut guard) = state_for_complete.lock() {
+                        *guard = None;
+                    }
+                    emitter_completed.status("idle");
+                    Ok(())
+                },
+            ))
+            .map_err(|e| format!("Failed to register Completed handler: {e}"))?;
+
+        // Start continuous recognition
+        session
+            .StartAsync()
+            .map_err(|e| format!("Failed to start recognition: {e}"))?
+            .get()
+            .map_err(|e| format!("Recognition start failed: {e}"))?;
+
+        // Store state
+        {
+            let mut guard = self.state.lock().map_err(|e| e.to_string())?;
+            *guard = Some(InnerState {
+                recognizer,
+                session,
+            });
+        }
+
+        emitter.status("listening");
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<(), String> {
+        let mut guard = self.state.lock().map_err(|e| e.to_string())?;
+        if let Some(inner) = guard.take() {
+            // Stop the continuous recognition session
+            inner
+                .session
+                .StopAsync()
+                .map_err(|e| format!("Failed to stop recognition: {e}"))?
+                .get()
+                .map_err(|e| format!("Stop recognition failed: {e}"))?;
+
+            // Close the recognizer to release resources
+            let closable: windows::Foundation::IClosable = windows::core::Interface::cast(&inner.recognizer)
+                .map_err(|e| format!("Failed to cast recognizer: {e}"))?;
+            closable
+                .Close()
+                .map_err(|e| format!("Failed to close recognizer: {e}"))?;
+        }
+        Ok(())
+    }
+
+    fn is_available(&self) -> bool {
+        // Try to create a SpeechRecognizer — if it succeeds, the API is available
+        SpeechRecognizer::Create().is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_id() {
+        let provider = WindowsSpeechProvider::new();
+        assert_eq!(provider.id(), "windows");
+    }
+}

--- a/src/lib/speech/plugins/apple/AppleSettingsTab.svelte
+++ b/src/lib/speech/plugins/apple/AppleSettingsTab.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { SUPPORTED_LANGUAGES } from "../../../settingsStore";
+  import type { AudioDevice } from "../../../speechService";
+
+  let {
+    config = $bindable(),
+    audioDevices,
+    micWarning,
+    microphoneDeviceId = $bindable(),
+  }: {
+    config: Record<string, unknown>;
+    audioDevices: AudioDevice[];
+    micWarning: string;
+    microphoneDeviceId: string;
+  } = $props();
+</script>
+
+<div class="section">
+  <h2>Apple Speech Settings</h2>
+  <div class="speech-notice">
+    <div class="notice-icon" title="Info">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div class="notice-content">
+      <strong>macOS Native Speech Recognition</strong>
+      <p>Uses Apple's SFSpeechRecognizer for speech-to-text. Audio may be sent to Apple's servers unless on-device recognition is enabled.</p>
+      <p>Requires <strong>Speech Recognition</strong> permission in System Settings → Privacy & Security.</p>
+    </div>
+  </div>
+  <label class="field">
+    <span class="label">Language</span>
+    <select bind:value={config.language}>
+      {#each SUPPORTED_LANGUAGES as lang}<option value={lang.code}>{lang.label} ({lang.code})</option>{/each}
+    </select>
+    <span class="hint">Language for Apple Speech recognition.</span>
+  </label>
+  <label class="field toggle-field">
+    <span class="label">On-Device Recognition</span>
+    <div class="toggle-row">
+      <input type="checkbox" checked={!!config.on_device} onchange={(e) => config.on_device = (e.target as HTMLInputElement).checked} class="toggle-checkbox" />
+      <span class="toggle-label">{config.on_device ? 'On' : 'Off'}</span>
+    </div>
+    <span class="hint">Process speech locally without sending audio to Apple's servers. Not all languages support on-device recognition.</span>
+  </label>
+  <label class="field">
+    <span class="label">Microphone</span>
+    <select bind:value={microphoneDeviceId}>
+      <option value="">System Default</option>
+      {#each audioDevices as device}<option value={device.deviceId}>{device.label}</option>{/each}
+    </select>
+    {#if micWarning}<span class="hint mic-warning">{micWarning}</span>{:else}<span class="hint">Select the microphone to use for dictation.</span>{/if}
+  </label>
+</div>

--- a/src/lib/speech/plugins/apple/index.ts
+++ b/src/lib/speech/plugins/apple/index.ts
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------
+// Apple Speech plugin descriptor — macOS native speech recognition
+// ---------------------------------------------------------------------------
+
+import type { SpeechProviderPlugin, SharedConfig } from "../../registry";
+import type { SpeechProvider } from "../../types";
+import { NativeProviderProxy } from "../../NativeProviderProxy";
+import { invoke } from "@tauri-apps/api/core";
+import { SUPPORTED_LANGUAGES } from "../../../speechConstants";
+import AppleSettingsTab from "./AppleSettingsTab.svelte";
+
+export interface AppleProviderConfig {
+  language: string;
+  on_device: boolean;
+}
+
+const applePlugin: SpeechProviderPlugin = {
+  id: "apple",
+  label: "Apple Speech",
+  description: "macOS native speech recognition (SFSpeechRecognizer)",
+
+  executionContext: "native",
+  capabilities: new Set(["auto-punctuation"]),
+
+  supportedLanguages: SUPPORTED_LANGUAGES,
+  languageMode: "single",
+  languageConfigKey: "language",
+
+  defaultConfig(): Record<string, unknown> {
+    return {
+      language: "en-US",
+      on_device: false,
+    } satisfies AppleProviderConfig;
+  },
+
+  canStart(_config: Record<string, unknown>): { ready: boolean; error?: string } {
+    return { ready: true };
+  },
+
+  async canStartAsync(_config: Record<string, unknown>): Promise<{ ready: boolean; error?: string }> {
+    try {
+      const available = await invoke<boolean>("native_speech_available", {
+        providerId: "apple",
+      });
+      if (!available) {
+        return {
+          ready: false,
+          error:
+            "Apple Speech Recognition is not available. Grant permission in System Settings → Privacy & Security → Speech Recognition.",
+        };
+      }
+      return { ready: true };
+    } catch {
+      return { ready: true };
+    }
+  },
+
+  createProvider(config: Record<string, unknown>, shared: SharedConfig): SpeechProvider {
+    return new NativeProviderProxy("apple", {
+      ...config,
+      microphone: shared.microphone_device_id,
+    });
+  },
+
+  SettingsComponent: AppleSettingsTab as any,
+};
+
+export default applePlugin;

--- a/src/lib/speech/plugins/index.ts
+++ b/src/lib/speech/plugins/index.ts
@@ -12,4 +12,26 @@ providerRegistry.register(osPlugin);
 providerRegistry.register(azurePlugin);
 providerRegistry.register(whisperPlugin);
 
+// Platform-specific native providers — registered conditionally
+const isMac =
+  typeof navigator !== "undefined" &&
+  (navigator.platform?.toLowerCase().includes("mac") ||
+    navigator.userAgent?.includes("Macintosh"));
+const isWindows =
+  typeof navigator !== "undefined" &&
+  (navigator.platform?.toLowerCase().includes("win") ||
+    navigator.userAgent?.includes("Windows"));
+
+if (isMac) {
+  import("./apple").then(({ default: applePlugin }) => {
+    providerRegistry.register(applePlugin);
+  });
+}
+
+if (isWindows) {
+  import("./windows").then(({ default: windowsPlugin }) => {
+    providerRegistry.register(windowsPlugin);
+  });
+}
+
 export { providerRegistry };

--- a/src/lib/speech/plugins/windows/WindowsSettingsTab.svelte
+++ b/src/lib/speech/plugins/windows/WindowsSettingsTab.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { SUPPORTED_LANGUAGES } from "../../../settingsStore";
+  import type { AudioDevice } from "../../../speechService";
+
+  let {
+    config = $bindable(),
+    audioDevices,
+    micWarning,
+    microphoneDeviceId = $bindable(),
+  }: {
+    config: Record<string, unknown>;
+    audioDevices: AudioDevice[];
+    micWarning: string;
+    microphoneDeviceId: string;
+  } = $props();
+</script>
+
+<div class="section">
+  <h2>Windows Speech Settings</h2>
+  <div class="speech-notice">
+    <div class="notice-icon" title="Info">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    </div>
+    <div class="notice-content">
+      <strong>Windows Native Speech Recognition</strong>
+      <p>Uses the Windows Speech Recognition API (UWP). Dictation mode may send audio to Microsoft's servers for processing.</p>
+      <p>Ensure <strong>Online speech recognition</strong> is enabled in Settings → Privacy → Speech.</p>
+    </div>
+  </div>
+  <label class="field">
+    <span class="label">Language</span>
+    <select bind:value={config.language}>
+      {#each SUPPORTED_LANGUAGES as lang}<option value={lang.code}>{lang.label} ({lang.code})</option>{/each}
+    </select>
+    <span class="hint">Language for Windows speech recognition. Ensure the language pack is installed in Windows Settings.</span>
+  </label>
+  <label class="field">
+    <span class="label">Microphone</span>
+    <select bind:value={microphoneDeviceId}>
+      <option value="">System Default</option>
+      {#each audioDevices as device}<option value={device.deviceId}>{device.label}</option>{/each}
+    </select>
+    {#if micWarning}<span class="hint mic-warning">{micWarning}</span>{:else}<span class="hint">Select the microphone to use for dictation.</span>{/if}
+  </label>
+</div>

--- a/src/lib/speech/plugins/windows/index.ts
+++ b/src/lib/speech/plugins/windows/index.ts
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------
+// Windows Speech plugin descriptor — Windows native speech recognition
+// ---------------------------------------------------------------------------
+
+import type { SpeechProviderPlugin, SharedConfig } from "../../registry";
+import type { SpeechProvider } from "../../types";
+import { NativeProviderProxy } from "../../NativeProviderProxy";
+import { invoke } from "@tauri-apps/api/core";
+import { SUPPORTED_LANGUAGES } from "../../../speechConstants";
+import WindowsSettingsTab from "./WindowsSettingsTab.svelte";
+
+export interface WindowsProviderConfig {
+  language: string;
+}
+
+const windowsPlugin: SpeechProviderPlugin = {
+  id: "windows",
+  label: "Windows Speech",
+  description: "Windows native speech recognition (UWP SpeechRecognizer)",
+
+  executionContext: "native",
+  capabilities: new Set(["auto-punctuation"]),
+
+  supportedLanguages: SUPPORTED_LANGUAGES,
+  languageMode: "single",
+  languageConfigKey: "language",
+
+  defaultConfig(): Record<string, unknown> {
+    return {
+      language: "en-US",
+    } satisfies WindowsProviderConfig;
+  },
+
+  canStart(_config: Record<string, unknown>): { ready: boolean; error?: string } {
+    return { ready: true };
+  },
+
+  async canStartAsync(_config: Record<string, unknown>): Promise<{ ready: boolean; error?: string }> {
+    try {
+      const available = await invoke<boolean>("native_speech_available", {
+        providerId: "windows",
+      });
+      if (!available) {
+        return {
+          ready: false,
+          error:
+            "Windows Speech Recognition is not available. Check Settings → Privacy → Speech, inking, & typing.",
+        };
+      }
+      return { ready: true };
+    } catch {
+      return { ready: true };
+    }
+  },
+
+  createProvider(config: Record<string, unknown>, shared: SharedConfig): SpeechProvider {
+    return new NativeProviderProxy("windows", {
+      ...config,
+      microphone: shared.microphone_device_id,
+    });
+  },
+
+  SettingsComponent: WindowsSettingsTab as any,
+};
+
+export default windowsPlugin;

--- a/src/test/applePlugin.test.ts
+++ b/src/test/applePlugin.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import applePlugin from "../lib/speech/plugins/apple";
+import { NativeProviderProxy } from "../lib/speech/NativeProviderProxy";
+import { invoke } from "@tauri-apps/api/core";
+
+describe("Apple Speech plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("has correct id and label", () => {
+    expect(applePlugin.id).toBe("apple");
+    expect(applePlugin.label).toBe("Apple Speech");
+  });
+
+  it("has native execution context", () => {
+    expect(applePlugin.executionContext).toBe("native");
+  });
+
+  it("has auto-punctuation capability", () => {
+    expect(applePlugin.capabilities.has("auto-punctuation")).toBe(true);
+  });
+
+  it("uses single language mode", () => {
+    expect(applePlugin.languageMode).toBe("single");
+    expect(applePlugin.languageConfigKey).toBe("language");
+  });
+
+  it("provides sensible default config", () => {
+    const config = applePlugin.defaultConfig();
+    expect(config.language).toBe("en-US");
+    expect(config.on_device).toBe(false);
+  });
+
+  it("canStart returns ready", () => {
+    const result = applePlugin.canStart({});
+    expect(result.ready).toBe(true);
+  });
+
+  it("canStartAsync checks native availability", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const result = await applePlugin.canStartAsync!({});
+    expect(result.ready).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("native_speech_available", {
+      providerId: "apple",
+    });
+  });
+
+  it("canStartAsync returns error when not available", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const result = await applePlugin.canStartAsync!({});
+    expect(result.ready).toBe(false);
+    expect(result.error).toContain("Apple Speech Recognition");
+  });
+
+  it("createProvider returns NativeProviderProxy", () => {
+    const provider = applePlugin.createProvider(
+      { language: "de-DE", on_device: true },
+      { microphone_device_id: "mic-1", phrase_list: [], silence_timeout_seconds: 5 },
+    );
+    expect(provider).toBeInstanceOf(NativeProviderProxy);
+  });
+
+  it("createProvider passes config and shared microphone", () => {
+    const provider = applePlugin.createProvider(
+      { language: "fr-FR", on_device: false },
+      { microphone_device_id: "mic-2", phrase_list: [], silence_timeout_seconds: 5 },
+    );
+    // Start the provider to verify the config is passed through
+    const callbacks = {
+      onInterim: vi.fn(),
+      onFinal: vi.fn(),
+      onError: vi.fn(),
+      onStatusChange: vi.fn(),
+    };
+    provider.start(callbacks);
+    expect(invoke).toHaveBeenCalledWith("native_speech_start", {
+      providerId: "apple",
+      config: { language: "fr-FR", on_device: false, microphone: "mic-2" },
+    });
+  });
+
+  it("has a SettingsComponent", () => {
+    expect(applePlugin.SettingsComponent).toBeDefined();
+  });
+});

--- a/src/test/windowsPlugin.test.ts
+++ b/src/test/windowsPlugin.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import windowsPlugin from "../lib/speech/plugins/windows";
+import { NativeProviderProxy } from "../lib/speech/NativeProviderProxy";
+import { invoke } from "@tauri-apps/api/core";
+
+describe("Windows Speech plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("has correct id and label", () => {
+    expect(windowsPlugin.id).toBe("windows");
+    expect(windowsPlugin.label).toBe("Windows Speech");
+  });
+
+  it("has native execution context", () => {
+    expect(windowsPlugin.executionContext).toBe("native");
+  });
+
+  it("has auto-punctuation capability", () => {
+    expect(windowsPlugin.capabilities.has("auto-punctuation")).toBe(true);
+  });
+
+  it("uses single language mode", () => {
+    expect(windowsPlugin.languageMode).toBe("single");
+    expect(windowsPlugin.languageConfigKey).toBe("language");
+  });
+
+  it("provides sensible default config", () => {
+    const config = windowsPlugin.defaultConfig();
+    expect(config.language).toBe("en-US");
+  });
+
+  it("canStart returns ready", () => {
+    const result = windowsPlugin.canStart({});
+    expect(result.ready).toBe(true);
+  });
+
+  it("canStartAsync checks native availability", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const result = await windowsPlugin.canStartAsync!({});
+    expect(result.ready).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("native_speech_available", {
+      providerId: "windows",
+    });
+  });
+
+  it("canStartAsync returns error when not available", async () => {
+    (invoke as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const result = await windowsPlugin.canStartAsync!({});
+    expect(result.ready).toBe(false);
+    expect(result.error).toContain("Windows Speech Recognition");
+  });
+
+  it("createProvider returns NativeProviderProxy", () => {
+    const provider = windowsPlugin.createProvider(
+      { language: "de-DE" },
+      { microphone_device_id: "mic-1", phrase_list: [], silence_timeout_seconds: 5 },
+    );
+    expect(provider).toBeInstanceOf(NativeProviderProxy);
+  });
+
+  it("createProvider passes config and shared microphone", () => {
+    const provider = windowsPlugin.createProvider(
+      { language: "ja-JP" },
+      { microphone_device_id: "mic-3", phrase_list: [], silence_timeout_seconds: 5 },
+    );
+    const callbacks = {
+      onInterim: vi.fn(),
+      onFinal: vi.fn(),
+      onError: vi.fn(),
+      onStatusChange: vi.fn(),
+    };
+    provider.start(callbacks);
+    expect(invoke).toHaveBeenCalledWith("native_speech_start", {
+      providerId: "windows",
+      config: { language: "ja-JP", microphone: "mic-3" },
+    });
+  });
+
+  it("has a SettingsComponent", () => {
+    expect(windowsPlugin.SettingsComponent).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds platform-native speech recognition providers that use OS-level APIs instead of browser-based Web Speech API or external services.

Closes #14

## What's Changed

### macOS — Apple Speech (`SFSpeechRecognizer` + `AVAudioEngine`)
- Full `SFSpeechRecognizer` integration via the `objc2` ecosystem (`objc2-speech`, `objc2-avf-audio`, `block2`)
- `AVAudioEngine` captures microphone audio and feeds it to `SFSpeechAudioBufferRecognitionRequest`
- On-device recognition toggle (for supported languages/models)
- Authorization flow with permission prompts
- Locale-based language selection

### Windows — UWP Speech (`Windows.Media.SpeechRecognition`)
- `SpeechRecognizer` with `ContinuousRecognitionSession` for real-time dictation
- `HypothesisGenerated` events for interim text, `ResultGenerated` for final text
- `SpeechRecognitionTopicConstraint::Dictation` grammar for free-form speech
- Language selection via `Windows.Globalization.Language`
- Proper resource cleanup via `IClosable`

### Architecture
- Integrates with existing `NativeSpeechProvider` trait and `NativeSpeechRegistry`
- Frontend plugins follow `SpeechProviderPlugin` interface with `NativeProviderProxy` bridge
- Platform-conditional compilation (`cfg(target_os)`) — zero overhead on non-target platforms
- Dynamic imports for platform-specific frontend plugins
- Settings UI tabs for each platform (language selector, on-device toggle for Apple, mic selector)

## Files

### Created
| File | Description |
|------|-------------|
| `src-tauri/src/speech/apple.rs` | macOS native speech provider |
| `src-tauri/src/speech/windows.rs` | Windows native speech provider |
| `src/lib/speech/plugins/apple/index.ts` | Apple plugin descriptor |
| `src/lib/speech/plugins/apple/AppleSettingsTab.svelte` | Apple settings UI |
| `src/lib/speech/plugins/windows/index.ts` | Windows plugin descriptor |
| `src/lib/speech/plugins/windows/WindowsSettingsTab.svelte` | Windows settings UI |
| `src/test/applePlugin.test.ts` | Apple plugin tests (11 tests) |
| `src/test/windowsPlugin.test.ts` | Windows plugin tests (11 tests) |

### Modified
| File | Change |
|------|--------|
| `src-tauri/Cargo.toml` | Added `objc2-speech`, `objc2-avf-audio`, `block2` (macOS) and `windows` crate (Windows) |
| `src-tauri/src/speech/mod.rs` | cfg-gated `apple` and `windows` module declarations |
| `src-tauri/src/lib.rs` | Provider registration in app setup |
| `src-tauri/Info.plist` | `NSSpeechRecognitionUsageDescription` permission |
| `src/lib/speech/plugins/index.ts` | Conditional platform-specific plugin registration |

## Verification

- ✅ `cargo check` — 0 errors, 0 warnings (macOS)
- ✅ `npx vitest run` — 528 tests passed (37 test files), including 22 new plugin tests
- ✅ `npx svelte-check` — 0 errors, 0 warnings

## Notes
- Windows provider compilation can only be fully verified on Windows (cross-compilation not practical for WinRT)
- Apple Speech has a ~1 minute recognition limit per session; the provider emits `idle` status when the session naturally ends
- On-device recognition availability depends on the language and macOS version